### PR TITLE
Fix crash on invalid query

### DIFF
--- a/src/OutputArea.tsx
+++ b/src/OutputArea.tsx
@@ -1,82 +1,96 @@
 import { 資料 } from "qieyun";
 import { forwardRef, memo, useMemo, useRef } from "react";
 import CharInfo from "./CharInfo";
-import { cmp, iter描述, 常見字頻序, 查詢方式, 查詢音韻地位, 顯示哪些字 } from "./utils";
+import { cmp, iter描述, 常見字頻序, 顯示哪些字 } from "./utils";
+import { QueryResult } from "./App";
 
-export default memo(
-	forwardRef<
-		HTMLOutputElement,
-		{
-			查詢方式: 查詢方式;
-			用户輸入: string;
-			setInvalid: (invalid: boolean) => void;
-			顯示哪些字: 顯示哪些字;
-			charsPerLine: number;
-			charWidth: number;
-			copy字頭: { current: string };
+const OutputArea = forwardRef<
+	HTMLOutputElement,
+	{
+		queryResult: QueryResult;
+		顯示哪些字: 顯示哪些字;
+		charsPerLine: number;
+		charWidth: number;
+		copy字頭: { current: string };
+	}
+>(function renderOutputArea({ queryResult, 顯示哪些字, charsPerLine, charWidth, copy字頭 }, ref) {
+	const toggleCharInfo = useRef<(i: number) => void>();
+
+	const { 查詢方式, 用户輸入, err, 音韻地位們 } = queryResult;
+	const 字頭們 = useMemo(() => {
+		if (err) {
+			return [];
 		}
-	>(function OutputArea({ 查詢方式, 用户輸入, setInvalid, 顯示哪些字, charsPerLine, charWidth, copy字頭 }, ref) {
-		const toggleCharInfo = useRef<(i: number) => void>();
-
-		try {
-			const 音韻地位們 = useMemo(() => 查詢音韻地位[查詢方式](用户輸入), [查詢方式, 用户輸入]);
-			const 字頭們 = useMemo(() => {
-				const 結果 = new Set<string>();
-				for (const 音韻地位 of 音韻地位們) {
-					const 條目 = 資料.query音韻地位(音韻地位);
-					if (顯示哪些字 === "一個音韻地位只顯示一個代表字" && 條目.length) {
-						結果.add(條目[0].字頭);
-					} else {
-						for (const { 字頭 } of 條目) {
-							if (顯示哪些字 === "顯示所有字" || 常見字頻序.has(字頭)) {
-								結果.add(字頭);
-							}
-						}
+		const 結果 = new Set<string>();
+		for (const 音韻地位 of 音韻地位們) {
+			const 條目 = 資料.query音韻地位(音韻地位);
+			if (顯示哪些字 === "一個音韻地位只顯示一個代表字" && 條目.length) {
+				結果.add(條目[0].字頭);
+			} else {
+				for (const { 字頭 } of 條目) {
+					if (顯示哪些字 === "顯示所有字" || 常見字頻序.has(字頭)) {
+						結果.add(字頭);
 					}
 				}
-				return [...結果].sort(cmp);
-			}, [查詢方式, 用户輸入, 顯示哪些字]);
-
-			setInvalid(false);
-			const lines: JSX.Element[][] = [];
-			let chars: JSX.Element[] = [];
-			copy字頭.current = 字頭們.join("");
-			字頭們.forEach((字頭, i) => {
-				if (!(i % charsPerLine)) {
-					if (i) lines.push(chars);
-					chars = [];
-				}
-				chars.push(
-					<button key={字頭} className="char" onClick={() => toggleCharInfo.current?.(i)}>
-						{字頭}
-					</button>
-				);
-			});
-			lines.push(chars);
-			return 字頭們.length ? (
-				<output id="outputArea" ref={ref}>
-					{lines.map((chars, order) => (
-						<div key={order} className="line" style={{ order }}>
-							{chars}
-						</div>
-					))}
-					<CharInfo
-						key={copy字頭.current}
-						字頭們={字頭們}
-						描述們={new Set(iter描述(音韻地位們))}
-						charsPerLine={charsPerLine}
-						charWidth={charWidth}
-						toggleCharInfo={toggleCharInfo}
-					/>
-				</output>
-			) : (
-				<output id="outputArea" className="noResult" ref={ref}>
-					無結果
-				</output>
-			);
-		} catch (err) {
-			setInvalid(true);
-			return <output id="errorArea" lang="en-x-code" ref={ref}>{`${err}\n${(err as Error).stack}`}</output>;
+			}
 		}
-	})
-);
+		return [...結果].sort(cmp);
+	}, [查詢方式, 用户輸入, 顯示哪些字]);
+
+	if (err) {
+		let message = String(err);
+		if (process.env.NODE_ENV !== "production") {
+			if (err instanceof Error && err.stack) {
+				message += `\n${err.stack}`;
+			}
+		}
+		return (
+			<output id="errorArea" lang="en-x-code" ref={ref}>
+				{message}
+			</output>
+		);
+	}
+
+	const lines: JSX.Element[][] = [];
+	let chars: JSX.Element[] = [];
+	copy字頭.current = 字頭們.join("");
+	字頭們.forEach((字頭, i) => {
+		if (!(i % charsPerLine)) {
+			if (i) lines.push(chars);
+			chars = [];
+		}
+		chars.push(
+			<button key={字頭} className="char" onClick={() => toggleCharInfo.current?.(i)}>
+				{字頭}
+			</button>
+		);
+	});
+	lines.push(chars);
+	return 字頭們.length ? (
+		<output id="outputArea" ref={ref}>
+			{lines.map((chars, order) => (
+				<div key={order} className="line" style={{ order }}>
+					{chars}
+				</div>
+			))}
+			<CharInfo
+				key={copy字頭.current}
+				字頭們={字頭們}
+				描述們={new Set(iter描述(音韻地位們))}
+				charsPerLine={charsPerLine}
+				charWidth={charWidth}
+				toggleCharInfo={toggleCharInfo}
+			/>
+		</output>
+	) : (
+		<output id="outputArea" className="noResult" ref={ref}>
+			無結果
+		</output>
+	);
+});
+
+// HACK If we simply wrote `memo(forwardRef<...>(function ...))`, eslint would
+// complain about types, saying "missing prop validation". The exact reason is
+// still under investigation, but for now, spiltting it into two statements
+// seems to work around it.
+export default memo(OutputArea);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,3 +2,6 @@ declare module "*.txt" {
 	const content: string;
 	export default content;
 }
+
+// Parcel's Node-like API for telling between development and production.
+declare const process: { env: { NODE_ENV: string } };

--- a/src/style.css
+++ b/src/style.css
@@ -256,6 +256,7 @@ output {
 
 #errorArea {
 	color: #ff0032;
+	white-space: pre;
 }
 
 .hidden {


### PR DESCRIPTION
- Don't skip hooks. Use values to indicate error.

- As a bonus, data flow is also fixed: Don't call parent node's state setter during render. Compute them first at top level.